### PR TITLE
Fix strftime %N bug when nanosecond present

### DIFF
--- a/lib/DateTime/Incomplete.pm
+++ b/lib/DateTime/Incomplete.pm
@@ -546,7 +546,7 @@ sub _format_nanosecs
 
     # rd_nanosecs can have a fractional separator
     my ( $ret, $frac ) = split /[.,]/, $self->nanosecond;
-    $ret = sprintf "09d" => $ret;  # unless length( $ret ) == 9;
+    $ret = sprintf "%09d" => $ret;  # unless length( $ret ) == 9;
     $ret .= $frac if $frac;
 
     return substr( $ret, 0, $precision );

--- a/t/13strftime.t
+++ b/t/13strftime.t
@@ -13,7 +13,7 @@ BEGIN
 
 use strict;
 
-use Test::More tests => 100;
+use Test::More tests => 101;
 
 use DateTime::Incomplete;
 use DateTime;
@@ -125,6 +125,16 @@ while (<DATA>)
 # %Oq	III
 # %OY	MCMXCIX
 # %Oy	XCIX
+
+# Test strftime formatting of nanoseconds, most-trivial cases
+subtest 'strfnano' => sub {
+    my $dti = DateTime::Incomplete->new( nanosecond => 987654321 );
+    isa_ok ($dti, 'DateTime::Incomplete', '$dti');
+    is ($dti->strftime('%N'), '987654321', 'N');
+    $dti = DateTime::Incomplete->new( year => '1973' );
+    isa_ok ($dti, 'DateTime::Incomplete', '$dti 1973');
+    is ($dti->strftime('%N'), 'xxxxxxxxx', 'Nx');
+};				# subtest 'strfnano'
 
 __DATA__
 year => undef


### PR DESCRIPTION
Without nanosecond present in a DT::Incomplete, %N works fine (produces 'xxxxxxxxx'). But when nanosecond _is_ present, it produced '09d', rather than the value of nanosecond. 

This patch fixes that by adding the missing '%'.

Also add test that fails before the fix and passes after.